### PR TITLE
feat(ui): add ErrorBoundary, Loading component and loading/error states for Collect and QRScanner

### DIFF
--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,62 @@
+import * as React from "react";
+
+type Props = {
+  children: React.ReactNode;
+};
+
+type State = {
+  hasError: boolean;
+  error: Error | null;
+};
+
+export class ErrorBoundary extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false, error: null };
+    this.reset = this.reset.bind(this);
+  }
+
+  static getDerivedStateFromError(error: Error) {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    // You can log the error to an error reporting service here
+    // console.error(error, info);
+  }
+
+  reset() {
+    this.setState({ hasError: false, error: null });
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="min-h-screen flex items-center justify-center bg-background px-4">
+          <div className="max-w-xl w-full">
+            <div className="rounded-lg border border-border p-6 bg-muted">
+              <h2 className="text-xl font-bold mb-2">Something went wrong</h2>
+              <p className="text-sm text-muted-foreground mb-4">
+                An unexpected error occurred. You can retry or report this issue if it persists.
+              </p>
+              <div className="flex gap-2">
+                <button className="px-4 py-2 bg-primary text-primary-foreground rounded" onClick={this.reset}>
+                  Retry
+                </button>
+                <a href="/" className="px-4 py-2 border rounded">Go Home</a>
+              </div>
+              <details className="mt-4 text-xs text-muted-foreground">
+                <summary>Debug info</summary>
+                <pre className="whitespace-pre-wrap">{String(this.state.error)}</pre>
+              </details>
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/src/components/QRScanner.tsx
+++ b/src/components/QRScanner.tsx
@@ -79,11 +79,20 @@ const mockProvenanceData = {
 export const QRScanner = () => {
   const [isScanning, setIsScanning] = useState(false);
   const [showResults, setShowResults] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   const handleScan = () => {
+    setError(null);
     setIsScanning(true);
-    // Simulate scanning delay
+    // Simulate scanning delay and possible failure
     setTimeout(() => {
+      const failed = Math.random() < 0.15;
+      if (failed) {
+        setIsScanning(false);
+        setError("Failed to retrieve provenance data. Please try again.");
+        return;
+      }
+
       setIsScanning(false);
       setShowResults(true);
     }, 2000);
@@ -204,7 +213,7 @@ export const QRScanner = () => {
           </p>
         </div>
 
-        {!showResults ? (
+  {!showResults ? (
           <div className="max-w-md mx-auto">
             <Card className="p-8 text-center shadow-elevation">
               <div className="mb-6">
@@ -222,25 +231,47 @@ export const QRScanner = () => {
                 </p>
               </div>
               
-              <Button 
-                variant="botanical" 
-                size="lg" 
-                onClick={handleScan}
-                disabled={isScanning}
-                className="w-full shadow-botanical"
-              >
-                {isScanning ? (
-                  <>
-                    <div className="animate-spin mr-2 h-4 w-4 border-2 border-primary-foreground/30 border-t-primary-foreground rounded-full" />
-                    Scanning...
-                  </>
-                ) : (
-                  <>
-                    <QrCode className="mr-2 h-4 w-4" />
-                    Demo Scan QR Code
-                  </>
-                )}
-              </Button>
+              {error ? (
+                <div className="space-y-3">
+                  <div className="rounded-md bg-destructive/10 border border-destructive p-4 text-sm text-destructive">{error}</div>
+                  <div className="flex gap-2">
+                    <Button variant="outline" onClick={() => { setError(null); handleScan(); }}>Retry</Button>
+                    <Button variant="botanical" size="lg" onClick={handleScan} disabled={isScanning} className="flex-1">
+                      {isScanning ? (
+                        <>
+                          <div className="animate-spin mr-2 h-4 w-4 border-2 border-primary-foreground/30 border-t-primary-foreground rounded-full" />
+                          Scanning...
+                        </>
+                      ) : (
+                        <>
+                          <QrCode className="mr-2 h-4 w-4" />
+                          Demo Scan QR Code
+                        </>
+                      )}
+                    </Button>
+                  </div>
+                </div>
+              ) : (
+                <Button 
+                  variant="botanical" 
+                  size="lg" 
+                  onClick={handleScan}
+                  disabled={isScanning}
+                  className="w-full shadow-botanical"
+                >
+                  {isScanning ? (
+                    <>
+                      <div className="animate-spin mr-2 h-4 w-4 border-2 border-primary-foreground/30 border-t-primary-foreground rounded-full" />
+                      Scanning...
+                    </>
+                  ) : (
+                    <>
+                      <QrCode className="mr-2 h-4 w-4" />
+                      Demo Scan QR Code
+                    </>
+                  )}
+                </Button>
+              )}
             </Card>
           </div>
         ) : (

--- a/src/components/ui/loading.tsx
+++ b/src/components/ui/loading.tsx
@@ -1,0 +1,15 @@
+import * as React from "react";
+
+export const Loading = ({ size = 6 }: { size?: number }) => {
+  const dimension = `${size}rem`;
+  return (
+    <div className="flex items-center justify-center">
+      <div
+        className="animate-spin rounded-full border-2 border-primary-foreground/30 border-t-primary-foreground"
+        style={{ width: dimension, height: dimension }}
+      />
+    </div>
+  );
+};
+
+export default Loading;

--- a/src/pages/Collect.tsx
+++ b/src/pages/Collect.tsx
@@ -41,10 +41,20 @@ const mockCollectionData = {
 export default function Collect() {
   const [isCollecting, setIsCollecting] = useState(false);
   const [collectionComplete, setCollectionComplete] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   const handleStartCollection = () => {
+    setError(null);
     setIsCollecting(true);
+    // Simulate API call with 80% success rate
     setTimeout(() => {
+      const failed = Math.random() < 0.2;
+      if (failed) {
+        setIsCollecting(false);
+        setError("Failed to record collection event. Network or blockchain error.");
+        return;
+      }
+
       setIsCollecting(false);
       setCollectionComplete(true);
     }, 3000);
@@ -159,30 +169,61 @@ export default function Collect() {
               </div>
 
               <div className="mt-6 pt-6 border-t border-border">
-                <Button 
-                  variant={collectionComplete ? "herb" : "botanical"} 
-                  size="lg" 
-                  className="w-full shadow-botanical"
-                  onClick={handleStartCollection}
-                  disabled={isCollecting}
-                >
-                  {isCollecting ? (
-                    <>
-                      <div className="animate-spin mr-2 h-4 w-4 border-2 border-primary-foreground/30 border-t-primary-foreground rounded-full" />
-                      Recording to Blockchain...
-                    </>
-                  ) : collectionComplete ? (
-                    <>
-                      <CheckCircle className="mr-2 h-4 w-4" />
-                      Collection Recorded Successfully
-                    </>
-                  ) : (
-                    <>
-                      <Upload className="mr-2 h-4 w-4" />
-                      Record Collection Event
-                    </>
-                  )}
-                </Button>
+                {error ? (
+                  <div className="space-y-3">
+                    <div className="rounded-md bg-destructive/10 border border-destructive p-4 text-sm text-destructive">
+                      {error}
+                    </div>
+                    <div className="flex gap-2">
+                      <Button variant="outline" onClick={() => { setError(null); handleStartCollection(); }}>
+                        Retry
+                      </Button>
+                      <Button variant={collectionComplete ? "herb" : "botanical"} size="lg" className="flex-1" onClick={handleStartCollection} disabled={isCollecting}>
+                        {isCollecting ? (
+                          <>
+                            <div className="animate-spin mr-2 h-4 w-4 border-2 border-primary-foreground/30 border-t-primary-foreground rounded-full" />
+                            Recording to Blockchain...
+                          </>
+                        ) : collectionComplete ? (
+                          <>
+                            <CheckCircle className="mr-2 h-4 w-4" />
+                            Collection Recorded Successfully
+                          </>
+                        ) : (
+                          <>
+                            <Upload className="mr-2 h-4 w-4" />
+                            Record Collection Event
+                          </>
+                        )}
+                      </Button>
+                    </div>
+                  </div>
+                ) : (
+                  <Button 
+                    variant={collectionComplete ? "herb" : "botanical"} 
+                    size="lg" 
+                    className="w-full shadow-botanical"
+                    onClick={handleStartCollection}
+                    disabled={isCollecting}
+                  >
+                    {isCollecting ? (
+                      <>
+                        <div className="animate-spin mr-2 h-4 w-4 border-2 border-primary-foreground/30 border-t-primary-foreground rounded-full" />
+                        Recording to Blockchain...
+                      </>
+                    ) : collectionComplete ? (
+                      <>
+                        <CheckCircle className="mr-2 h-4 w-4" />
+                        Collection Recorded Successfully
+                      </>
+                    ) : (
+                      <>
+                        <Upload className="mr-2 h-4 w-4" />
+                        Record Collection Event
+                      </>
+                    )}
+                  </Button>
+                )}
               </div>
             </Card>
 


### PR DESCRIPTION
I added ErrorBoundary (reusable), ui/Loading spinner, and wired basic error + retry UI into [Collect.tsx] and [QRScanner.tsx]
I left deterministic/simulated failure logic in place (Math.random) so you can test the UI; we can switch these to real API calls or remove simulation later. 
closes issue #5